### PR TITLE
Migration to CTO's firmware

### DIFF
--- a/src/cclink.zig
+++ b/src/cclink.zig
@@ -17,6 +17,21 @@ pub const Direction = enum(u1) {
 pub const Distance = packed struct(u32) {
     mm: i16 = 0,
     um: i16 = 0,
+
+    /// Cast distance value to millimeter floating point
+    pub fn toFloat(self: @This()) f32 {
+        return @as(f32, @floatFromInt(self.mm)) * 1 +
+            @as(f32, @floatFromInt(self.um)) * 0.001;
+    }
+
+    /// Cast millimiter unit value to Distance type
+    pub fn fromFloat(f: f32) @This() {
+        const mm: f32 = @trunc(f);
+        return .{
+            .mm = @intFromFloat(mm),
+            .um = @intFromFloat((f - mm) * 1000.0),
+        };
+    }
 };
 
 pub fn nestedWrite(

--- a/src/cclink.zig
+++ b/src/cclink.zig
@@ -14,6 +14,11 @@ pub const Direction = enum(u1) {
     }
 };
 
+pub const Distance = packed struct(u32) {
+    mm: i16 = 0,
+    um: i16 = 0,
+};
+
 pub fn nestedWrite(
     name: []const u8,
     val: anytype,

--- a/src/cclink/wr.zig
+++ b/src/cclink/wr.zig
@@ -17,7 +17,7 @@ pub const Wr = packed struct(u256) {
                 0 => self.axis1,
                 1 => self.axis2,
                 2 => self.axis3,
-                _ => error.InvalidAxis,
+                else => unreachable,
             };
         }
     } = .{},
@@ -32,7 +32,7 @@ pub const Wr = packed struct(u256) {
                 0 => self.axis1,
                 1 => self.axis2,
                 2 => self.axis3,
-                _ => error.InvalidAxis,
+                else => unreachable,
             };
         }
     } = .{},
@@ -47,7 +47,7 @@ pub const Wr = packed struct(u256) {
                 0 => self.axis1,
                 1 => self.axis2,
                 2 => self.axis3,
-                _ => error.InvalidAxis,
+                else => unreachable,
             };
         }
     } = .{},
@@ -62,7 +62,7 @@ pub const Wr = packed struct(u256) {
                 0 => self.axis1,
                 1 => self.axis2,
                 2 => self.axis3,
-                _ => error.InvalidAxis,
+                else => unreachable,
             };
         }
     } = .{},

--- a/src/cclink/wr.zig
+++ b/src/cclink/wr.zig
@@ -1,115 +1,155 @@
 const std = @import("std");
 const cclink = @import("../cclink.zig");
 
+const Distance = cclink.Distance;
 /// Registers written through CC-Link's "DevWr" device. Used as a "read"
 /// register bank.
 pub const Wr = packed struct(u256) {
-    command_response: CommandResponseCode = .none,
-    _16: u48 = 0,
-    carrier: packed struct(u192) {
-        axis1: Carrier = .{},
-        axis2: Carrier = .{},
-        axis3: Carrier = .{},
+    command_response: CommandResponseCode = .NoError,
+    slider_number: packed struct(u48) {
+        axis1: u16 = 0,
+        axis2: u16 = 0,
+        axis3: u16 = 0,
 
-        pub fn axis(self: @This(), a: u2) Carrier {
+        pub fn axis(self: @This(), a: u2) error{InvalidAxis}!u16 {
             return switch (a) {
                 0 => self.axis1,
                 1 => self.axis2,
                 2 => self.axis3,
-                3 => {
-                    std.log.err(
-                        "Invalid axis index 3 for `carrier`",
-                        .{},
-                    );
-                    unreachable;
-                },
+                _ => error.InvalidAxis,
+            };
+        }
+    } = .{},
+    slider_location: packed struct(u96) {
+        axis1: Distance = .{},
+        axis2: Distance = .{},
+        axis3: Distance = .{},
+
+        pub fn axis(self: @This(), a: u2) error{InvalidAxis}!Distance {
+            return switch (a) {
+                0 => self.axis1,
+                1 => self.axis2,
+                2 => self.axis3,
+                _ => error.InvalidAxis,
+            };
+        }
+    } = .{},
+    slider_state: packed struct(u48) {
+        axis1: SliderStateCode = .None,
+        axis2: SliderStateCode = .None,
+        axis3: SliderStateCode = .None,
+
+        pub fn axis(self: @This(), a: u2) error{InvalidAxis}!SliderStateCode {
+            return switch (a) {
+                0 => self.axis1,
+                1 => self.axis2,
+                2 => self.axis3,
+                _ => error.InvalidAxis,
+            };
+        }
+    } = .{},
+    pitch_count: packed struct(u48) {
+        axis1: i16 = 0,
+        axis2: i16 = 0,
+        axis3: i16 = 0,
+
+        pub fn axis(self: @This(), a: u2) error{InvalidAxis}!i16 {
+            return switch (a) {
+                0 => self.axis1,
+                1 => self.axis2,
+                2 => self.axis3,
+                _ => error.InvalidAxis,
             };
         }
     } = .{},
 
-    pub const Carrier = packed struct(u64) {
-        location: f32 = 0.0,
-        id: u10 = 0,
-        _42: u6 = 0,
-        arrived: bool = false,
-        auxiliary: bool = false,
-        enabled: bool = false,
-        /// Whether carrier is currently in quasi-enabled state. Quasi-enabled
-        /// state occurs when carrier is first entering a module, before it
-        /// has entered module enough to start servo control.
-        quasi: bool = false,
-        cas: packed struct {
-            /// Whether carrier's CAS (collision avoidance system) is enabled.
-            enabled: bool = false,
-            /// Whether carrier's CAS (collision avoidance system) is triggered.
-            triggered: bool = false,
-        } = .{},
-        initialized: bool = false,
-        _55: u1 = 0,
-        state: State = .none,
-        _60: u4 = 0,
-
-        pub const State = enum(u4) {
-            none = 0x0,
-
-            warmup_progressing,
-            warmup_completed,
-
-            move,
-            auxiliary,
-
-            forward_calibration_progressing,
-            forward_calibration_completed,
-            backward_calibration_progressing,
-            backward_calibration_completed,
-
-            forward_isolation_progressing,
-            forward_isolation_completed,
-            backward_isolation_progressing,
-            backward_isolation_completed,
-
-            pull,
-            push,
-
-            overcurrent,
-        };
-    };
-
-    pub const CommandResponseCode = enum(u16) {
-        none = 0,
-        success = 1,
-        invalid_cmd,
-        invalid_axis_id,
-        invalid_carrier_id,
-        conflicting_carrier_id,
-        invalid_carrier_target,
-        invalid_carrier_control,
-        invalid_carrier_vel,
-        invalid_carrier_acc,
-        carrier_not_found,
-        carrier_already_initialized,
-        invalid_parameters,
-        invalid_system_state,
-        _,
+    pub const CommandResponseCode = enum(i16) {
+        NoError = 0,
+        InvalidCommand = 1,
+        SliderNotFound = 2,
+        HomingFailed = 3,
+        InvalidParameter = 4,
+        InvalidSystemState = 5,
+        SliderAlreadyExists = 6,
+        InvalidAxis = 7,
 
         pub fn throwError(code: CommandResponseCode) !void {
             return switch (code) {
-                .none, .success => {},
-                .invalid_cmd => return error.InvalidCommand,
-                .invalid_axis_id => return error.InvalidAxis,
-                .invalid_carrier_id => return error.InvalidCarrierId,
-                .invalid_carrier_target => return error.InvalidCarrierTarget,
-                .invalid_carrier_control => return error.InvalidCarrierControl,
-                .invalid_carrier_vel => return error.InvalidCarrierVelocity,
-                .invalid_carrier_acc => return error.InvalidCarrierAcceleration,
-                .carrier_not_found => return error.CarrierNotFound,
-                .carrier_already_initialized => return error.CarrierAlreadyInitialized,
-                .invalid_parameters => return error.InvalidParameters,
-                .invalid_system_state => return error.InvalidSystemState,
-                .conflicting_carrier_id => return error.ConflictingCarrierId,
-                _ => return error.Unexpected,
+                .NoError => {},
+                .InvalidCommand => error.InvalidCommand,
+                .SliderNotFound => error.SliderNotFound,
+                .HomingFailed => error.HomingFailed,
+                .InvalidParameter => error.InvalidParameter,
+                .InvalidSystemState => error.InvalidSystemState,
+                .SliderAlreadyExists => error.SliderAlreadyExists,
+                .InvalidAxis => error.InvalidAxis,
             };
         }
+    };
+
+    pub const SliderStateCode = enum(u16) {
+        None = 0,
+        WarmupProgressing = 1,
+        WarmupCompleted = 2,
+        WarmupFault = 3,
+        CurrentBiasProgressing = 4,
+        CurrentBiasCompleted = 5,
+        HomeForward = 6,
+        HomeBackward = 7,
+        RampForwardProgressing = 8,
+        RampForwardCompleted = 9,
+        RampForwardFault = 10,
+        RampBackwardProgressing = 11,
+        RampBackwardCompleted = 12,
+        RampBackwardFault = 13,
+        CurrentStepProgressing = 20,
+        CurrentStepCompleted = 21,
+        CurrentStepFault = 22,
+        SpeedStepProgressing = 23,
+        SpeedStepCompleted = 24,
+        SpeedStepFault = 25,
+        PosStepProgressing = 26,
+        PosStepCompleted = 27,
+        PosStepFault = 28,
+        PosMoveProgressing = 29,
+        PosMoveCompleted = 30,
+        PosMoveFault = 31,
+        ForwardCalibrationProgressing = 32,
+        ForwardCalibrationCompleted = 33,
+        BackwardIsolationProgressing = 34,
+        BackwardIsolationCompleted = 35,
+        ForwardRecoveryProgressing = 36,
+        ForwardRecoveryCompleted = 37,
+        BackwardRecoveryProgressing = 38,
+        BackwardRecoveryCompleted = 39,
+        SpdMoveProgressing = 40,
+        SpdMoveCompleted = 41,
+        SpdMoveFault = 42,
+        NextAxisAuxiliary = 43,
+        // Note: Next Axis Completed will show even when the next axis is
+        // progressing, if the slider is paused for collision avoidance on the
+        // next axis.
+        NextAxisCompleted = 44,
+        PrevAxisAuxiliary = 45,
+        // Note: Prev Axis Completed will show even when the prev axis is
+        // progressing, if the slider is paused for collision avoidance on the
+        // prev axis.
+        PrevAxisCompleted = 46,
+        ForwardIsolationProgressing = 47,
+        ForwardIsolationCompleted = 48,
+        Overcurrent = 50,
+        CommunicationError = 51,
+        PullForwardProgressing = 52,
+        PullForwardCompleted = 53,
+        PullForwardFault = 54,
+        PullBackwardProgressing = 55,
+        PullBackwardCompleted = 56,
+        PullBackwardFault = 57,
+        BackwardCalibrationProgressing = 58,
+        BackwardCalibrationCompleted = 59,
+        BackwardCalibrationFault = 60,
+        ForwardCalibrationFault = 61,
+        _,
     };
 
     pub fn format(wr: Wr, writer: anytype) !void {

--- a/src/cclink/wr.zig
+++ b/src/cclink/wr.zig
@@ -11,8 +11,9 @@ pub const Wr = packed struct(u256) {
         axis2: u16 = 0,
         axis3: u16 = 0,
 
-        pub fn axis(self: @This(), a: u2) error{InvalidAxis}!u16 {
-            return switch (a) {
+        pub fn axis(self: @This(), local_axis: u2) u16 {
+            std.debug.assert(local_axis <= 2);
+            return switch (local_axis) {
                 0 => self.axis1,
                 1 => self.axis2,
                 2 => self.axis3,
@@ -25,8 +26,9 @@ pub const Wr = packed struct(u256) {
         axis2: Distance = .{},
         axis3: Distance = .{},
 
-        pub fn axis(self: @This(), a: u2) error{InvalidAxis}!Distance {
-            return switch (a) {
+        pub fn axis(self: @This(), local_axis: u2) Distance {
+            std.debug.assert(local_axis <= 2);
+            return switch (local_axis) {
                 0 => self.axis1,
                 1 => self.axis2,
                 2 => self.axis3,
@@ -39,8 +41,9 @@ pub const Wr = packed struct(u256) {
         axis2: SliderStateCode = .None,
         axis3: SliderStateCode = .None,
 
-        pub fn axis(self: @This(), a: u2) error{InvalidAxis}!SliderStateCode {
-            return switch (a) {
+        pub fn axis(self: @This(), local_axis: u2) SliderStateCode {
+            std.debug.assert(local_axis <= 2);
+            return switch (local_axis) {
                 0 => self.axis1,
                 1 => self.axis2,
                 2 => self.axis3,
@@ -53,8 +56,9 @@ pub const Wr = packed struct(u256) {
         axis2: i16 = 0,
         axis3: i16 = 0,
 
-        pub fn axis(self: @This(), a: u2) error{InvalidAxis}!i16 {
-            return switch (a) {
+        pub fn axis(self: @This(), local_axis: u2) i16 {
+            std.debug.assert(local_axis <= 2);
+            return switch (local_axis) {
                 0 => self.axis1,
                 1 => self.axis2,
                 2 => self.axis3,

--- a/src/cclink/ww.zig
+++ b/src/cclink/ww.zig
@@ -12,7 +12,7 @@ pub const Ww = packed struct(u256) {
     location_distance: Distance = .{},
     speed_percentage: u16 = 0,
     acceleration_percentage: u16 = 0,
-    _128: u128 = 0,
+    _112: u144 = 0,
 
     pub const CommandCode = enum(u16) {
         None = 0,
@@ -49,15 +49,6 @@ pub const Ww = packed struct(u256) {
 
 test "Ww" {
     try std.testing.expectEqual(32, @sizeOf(Ww));
-    try std.testing.expectEqual(
-        32,
-        @bitSizeOf(
-            @FieldType(
-                @FieldType(Ww, "carrier"),
-                "target",
-            ),
-        ),
-    );
 }
 
 test {

--- a/src/cclink/ww.zig
+++ b/src/cclink/ww.zig
@@ -1,61 +1,45 @@
 const std = @import("std");
 const cclink = @import("../cclink.zig");
 
+const Distance = cclink.Distance;
+
 /// Registers written through CC-Link's "DevWw" device. Used as a "write"
 /// register bank.
 pub const Ww = packed struct(u256) {
-    command: Command = .none,
-    axis: u16 = 0,
-    carrier: packed struct(u80) {
-        target: f32 = 0.0,
-        id: u10 = 0,
-        control_kind: ControlKind = .none,
-        disable_cas: bool = false,
-        isolate_link_prev_axis: bool = false,
-        isolate_link_next_axis: bool = false,
-        _46: u1 = 0,
-        velocity: u10 = 0,
-        /// Determines how the velocity value is interpreted:
-        /// - `false`: `velocity = 1` corresponds to 100 mm/s
-        /// - `true`:  `velocity = 1` corresponds to 0.1 mm/s
-        low_velocity: bool = false,
-        _59: u5 = 0,
-        acceleration: u16 = 0,
-    } = .{},
-    _112: u144 = 0,
+    command_code: CommandCode = .None,
+    command_slider_number: u16 = 0,
+    target_axis_number: u16 = 0,
+    location_distance: Distance = .{},
+    speed_percentage: u16 = 0,
+    acceleration_percentage: u16 = 0,
+    _128: u128 = 0,
 
-    pub const ControlKind = enum(u2) {
-        none = 0,
-        velocity = 1,
-        position = 2,
-    };
-
-    pub const Command = enum(i16) {
-        none = 0x0,
-
-        /// Find and set zero offset of axis's hall sensor angles.
-        set_sensors_zero = 0x1,
-        /// Set zero point of line at current carrier position.
-        set_line_zero = 0x2,
-
-        initialize_fwd = 0x3,
-        initialize_bwd = 0x4,
-
-        /// Set initialized carrier's ID at axis.
-        set_id_axis = 0x6,
-
-        /// Release carrier control.
-        release = 0x7,
-        /// Deinitialize carrier, releasing control and erasing stored info.
-        deinitialize = 0x8,
-
-        /// Absolute location movement.
-        move_abs = 0x10,
-        /// Relative distance movement.
-        move_rel = 0x11,
-
-        push = 0x20,
-        pull = 0x21,
+    pub const CommandCode = enum(u16) {
+        None = 0,
+        Home = 17,
+        // "By Position" commands calculate slider movement by constant hall
+        // sensor position feedback, and is much more precise in destination.
+        MoveSliderToAxisByPosition = 18,
+        MoveSliderToLocationByPosition = 19,
+        MoveSliderDistanceByPosition = 20,
+        // "By Speed" commands calculate slider movement by constant hall
+        // sensor speed feedback. It should mostly not be used, as the
+        // destination position becomes far too imprecise. However, it is
+        // meant to maintain a certain speed while the slider is traveling, and
+        // to avoid the requirement of having a known system position.
+        MoveSliderToAxisBySpeed = 21,
+        MoveSliderToLocationBySpeed = 22,
+        MoveSliderDistanceBySpeed = 23,
+        IsolateForward = 24,
+        IsolateBackward = 25,
+        Calibration = 26,
+        RecoverSystemSliders = 27,
+        RecoverSliderAtAxis = 28,
+        PushAxisSliderForward = 30,
+        PushAxisSliderBackward = 31,
+        PullAxisSliderForward = 32,
+        PullAxisSliderBackward = 33,
+        _,
     };
 
     pub fn format(ww: Ww, writer: anytype) !void {

--- a/src/cclink/x.zig
+++ b/src/cclink/x.zig
@@ -9,7 +9,7 @@ pub const X = packed struct(u64) {
     cc_link_enabled: bool = false, //X00
     service_enabled: bool = false, //X01
     ready_for_command: bool = false, //X02
-    servo_active: packed struct(u2) { //X03-X05
+    servo_active: packed struct(u3) { //X03-X05
         axis1: bool = false,
         axis2: bool = false,
         axis3: bool = false,

--- a/src/cclink/x.zig
+++ b/src/cclink/x.zig
@@ -20,7 +20,7 @@ pub const X = packed struct(u64) {
                 0 => self.axis1,
                 1 => self.axis2,
                 2 => self.axis3,
-                _ => error.InvalidAxis,
+                else => unreachable,
             };
         }
     } = .{},
@@ -40,7 +40,7 @@ pub const X = packed struct(u64) {
                 0 => self.axis1,
                 1 => self.axis2,
                 2 => self.axis3,
-                _ => error.InvalidAxis,
+                else => unreachable,
             };
         }
     } = .{},
@@ -55,7 +55,7 @@ pub const X = packed struct(u64) {
                 0 => self.axis1,
                 1 => self.axis2,
                 2 => self.axis3,
-                _ => error.InvalidAxis,
+                else => unreachable,
             };
         }
     } = .{},
@@ -70,7 +70,7 @@ pub const X = packed struct(u64) {
                 0 => self.axis1,
                 1 => self.axis2,
                 2 => self.axis3,
-                _ => error.InvalidAxis,
+                else => unreachable,
             };
         }
     } = .{},
@@ -85,7 +85,7 @@ pub const X = packed struct(u64) {
                 0 => self.axis1,
                 1 => self.axis2,
                 2 => self.axis3,
-                _ => error.InvalidAxis,
+                else => unreachable,
             };
         }
     } = .{},
@@ -124,7 +124,7 @@ pub const X = packed struct(u64) {
                 0 => self.axis1,
                 1 => self.axis2,
                 2 => self.axis3,
-                _ => error.InvalidAxis,
+                else => unreachable,
             };
         }
     } = .{},
@@ -139,7 +139,7 @@ pub const X = packed struct(u64) {
                 0 => self.axis1,
                 1 => self.axis2,
                 2 => self.axis3,
-                _ => error.InvalidAxis,
+                else => unreachable,
             };
         }
     } = .{},
@@ -175,7 +175,7 @@ pub const X = packed struct(u64) {
                     .back = self.axis3.back,
                     .front = self.axis3.front,
                 },
-                _ => error.InvalidAxis,
+                else => unreachable,
             };
         }
     } = .{},
@@ -190,7 +190,7 @@ pub const X = packed struct(u64) {
                 0 => self.axis1,
                 1 => self.axis2,
                 2 => self.axis3,
-                _ => error.InvalidAxis,
+                else => unreachable,
             };
         }
     } = .{},
@@ -205,7 +205,7 @@ pub const X = packed struct(u64) {
                 0 => self.axis1,
                 1 => self.axis2,
                 2 => self.axis3,
-                _ => error.InvalidAxis,
+                else => unreachable,
             };
         }
     } = .{},
@@ -242,7 +242,7 @@ pub const X = packed struct(u64) {
                     .back = self.axis3.back,
                     .front = self.axis3.front,
                 },
-                _ => error.InvalidAxis,
+                else => unreachable,
             };
         }
     } = .{},
@@ -257,7 +257,7 @@ pub const X = packed struct(u64) {
                 0 => self.axis1,
                 1 => self.axis2,
                 2 => self.axis3,
-                _ => error.InvalidAxis,
+                else => unreachable,
             };
         }
     } = .{},

--- a/src/cclink/x.zig
+++ b/src/cclink/x.zig
@@ -14,8 +14,9 @@ pub const X = packed struct(u64) {
         axis2: bool = false,
         axis3: bool = false,
 
-        pub fn axis(self: @This(), a: u2) error{InvalidAxis}!bool {
-            return switch (a) {
+        pub fn axis(self: @This(), local_axis: u2) bool {
+            std.debug.assert(local_axis <= 2);
+            return switch (local_axis) {
                 0 => self.axis1,
                 1 => self.axis2,
                 2 => self.axis3,
@@ -33,8 +34,9 @@ pub const X = packed struct(u64) {
         axis2: bool = false,
         axis3: bool = false,
 
-        pub fn axis(self: @This(), a: u2) error{InvalidAxis}!bool {
-            return switch (a) {
+        pub fn axis(self: @This(), local_axis: u2) bool {
+            std.debug.assert(local_axis <= 2);
+            return switch (local_axis) {
                 0 => self.axis1,
                 1 => self.axis2,
                 2 => self.axis3,
@@ -47,8 +49,9 @@ pub const X = packed struct(u64) {
         axis2: bool = false,
         axis3: bool = false,
 
-        pub fn axis(self: @This(), a: u2) error{InvalidAxis}!bool {
-            return switch (a) {
+        pub fn axis(self: @This(), local_axis: u2) bool {
+            std.debug.assert(local_axis <= 2);
+            return switch (local_axis) {
                 0 => self.axis1,
                 1 => self.axis2,
                 2 => self.axis3,
@@ -61,8 +64,9 @@ pub const X = packed struct(u64) {
         axis2: bool = false,
         axis3: bool = false,
 
-        pub fn axis(self: @This(), a: u2) error{InvalidAxis}!bool {
-            return switch (a) {
+        pub fn axis(self: @This(), local_axis: u2) bool {
+            std.debug.assert(local_axis <= 2);
+            return switch (local_axis) {
                 0 => self.axis1,
                 1 => self.axis2,
                 2 => self.axis3,
@@ -75,8 +79,9 @@ pub const X = packed struct(u64) {
         axis2: bool = false,
         axis3: bool = false,
 
-        pub fn axis(self: @This(), a: u2) error{InvalidAxis}!bool {
-            return switch (a) {
+        pub fn axis(self: @This(), local_axis: u2) bool {
+            std.debug.assert(local_axis <= 2);
+            return switch (local_axis) {
                 0 => self.axis1,
                 1 => self.axis2,
                 2 => self.axis3,
@@ -113,8 +118,9 @@ pub const X = packed struct(u64) {
         axis2: bool = false,
         axis3: bool = false,
 
-        pub fn axis(self: @This(), a: u2) error{InvalidAxis}!bool {
-            return switch (a) {
+        pub fn axis(self: @This(), local_axis: u2) bool {
+            std.debug.assert(local_axis <= 2);
+            return switch (local_axis) {
                 0 => self.axis1,
                 1 => self.axis2,
                 2 => self.axis3,
@@ -127,8 +133,9 @@ pub const X = packed struct(u64) {
         axis2: bool = false,
         axis3: bool = false,
 
-        pub fn axis(self: @This(), a: u2) error{InvalidAxis}!bool {
-            return switch (a) {
+        pub fn axis(self: @This(), local_axis: u2) bool {
+            std.debug.assert(local_axis <= 2);
+            return switch (local_axis) {
                 0 => self.axis1,
                 1 => self.axis2,
                 2 => self.axis3,
@@ -150,11 +157,12 @@ pub const X = packed struct(u64) {
             front: bool = false,
         } = .{},
 
-        pub fn axis(self: @This(), a: u2) error{InvalidAxis}!packed struct(u2) {
+        pub fn axis(self: @This(), local_axis: u2) packed struct(u2) {
             back: bool,
             front: bool,
         } {
-            return switch (a) {
+            std.debug.assert(local_axis <= 2);
+            return switch (local_axis) {
                 0 => .{
                     .back = self.axis1.back,
                     .front = self.axis1.front,
@@ -176,8 +184,9 @@ pub const X = packed struct(u64) {
         axis2: bool = false,
         axis3: bool = false,
 
-        pub fn axis(self: @This(), a: u2) error{InvalidAxis}!bool {
-            return switch (a) {
+        pub fn axis(self: @This(), local_axis: u2) bool {
+            std.debug.assert(local_axis <= 2);
+            return switch (local_axis) {
                 0 => self.axis1,
                 1 => self.axis2,
                 2 => self.axis3,
@@ -190,8 +199,9 @@ pub const X = packed struct(u64) {
         axis2: bool = false,
         axis3: bool = false,
 
-        pub fn axis(self: @This(), a: u2) error{InvalidAxis}!bool {
-            return switch (a) {
+        pub fn axis(self: @This(), local_axis: u2) bool {
+            std.debug.assert(local_axis <= 2);
+            return switch (local_axis) {
                 0 => self.axis1,
                 1 => self.axis2,
                 2 => self.axis3,
@@ -216,9 +226,10 @@ pub const X = packed struct(u64) {
 
         pub fn axis(
             self: @This(),
-            a: u2,
-        ) error{InvalidAxis}!packed struct(u2) { back: bool, front: bool } {
-            return switch (a) {
+            local_axis: u2,
+        ) packed struct(u2) { back: bool, front: bool } {
+            std.debug.assert(local_axis <= 2);
+            return switch (local_axis) {
                 0 => .{
                     .back = self.axis1.back,
                     .front = self.axis1.front,
@@ -240,8 +251,9 @@ pub const X = packed struct(u64) {
         axis2: bool = false,
         axis3: bool = false,
 
-        pub fn axis(self: @This(), a: u2) error{InvalidAxis}!bool {
-            return switch (a) {
+        pub fn axis(self: @This(), local_axis: u2) bool {
+            std.debug.assert(local_axis <= 2);
+            return switch (local_axis) {
                 0 => self.axis1,
                 1 => self.axis2,
                 2 => self.axis3,

--- a/src/cclink/x.zig
+++ b/src/cclink/x.zig
@@ -6,46 +6,151 @@ const Direction = cclink.Direction;
 /// Registers written through CC-Link's "DevX" device. Used as a "read"
 /// register bank.
 pub const X = packed struct(u64) {
-    cc_link_enabled: bool = false,
-    command_ready: bool = false,
-    emergency_stop_enabled: bool = false,
-    paused: bool = false,
-    motor_active: packed struct(u3) {
+    cc_link_enabled: bool = false, //X00
+    service_enabled: bool = false, //X01
+    ready_for_command: bool = false, //X02
+    servo_active: packed struct(u2) { //X03-X05
         axis1: bool = false,
         axis2: bool = false,
         axis3: bool = false,
 
-        pub fn axis(self: @This(), a: u2) bool {
+        pub fn axis(self: @This(), a: u2) error{InvalidAxis}!bool {
             return switch (a) {
                 0 => self.axis1,
                 1 => self.axis2,
                 2 => self.axis3,
-                3 => {
-                    std.log.err(
-                        "Invalid axis index 3 for `motor_active`",
-                        .{},
-                    );
-                    unreachable;
-                },
+                _ => error.InvalidAxis,
             };
         }
     } = .{},
-    calibrating: bool = false,
+    servo_enabled: bool = false, //X06
+    emergency_stop_enabled: bool = false, //X07
+    paused: bool = false, //X08
+    axis_slider_info_cleared: bool = false, //X09
+    command_received: bool = false, //X0A
+    axis_enabled: packed struct(u3) { //X0B,X0C,X0D
+        axis1: bool = false,
+        axis2: bool = false,
+        axis3: bool = false,
+
+        pub fn axis(self: @This(), a: u2) error{InvalidAxis}!bool {
+            return switch (a) {
+                0 => self.axis1,
+                1 => self.axis2,
+                2 => self.axis3,
+                _ => error.InvalidAxis,
+            };
+        }
+    } = .{},
+    in_position: packed struct(u3) { //X0E,X0F,X10
+        axis1: bool = false,
+        axis2: bool = false,
+        axis3: bool = false,
+
+        pub fn axis(self: @This(), a: u2) error{InvalidAxis}!bool {
+            return switch (a) {
+                0 => self.axis1,
+                1 => self.axis2,
+                2 => self.axis3,
+                _ => error.InvalidAxis,
+            };
+        }
+    } = .{},
+    entered_front: packed struct(u3) { //X11,X12,X13
+        axis1: bool = false,
+        axis2: bool = false,
+        axis3: bool = false,
+
+        pub fn axis(self: @This(), a: u2) error{InvalidAxis}!bool {
+            return switch (a) {
+                0 => self.axis1,
+                1 => self.axis2,
+                2 => self.axis3,
+                _ => error.InvalidAxis,
+            };
+        }
+    } = .{},
+    entered_back: packed struct(u3) { //X14,X15,X16
+        axis1: bool = false,
+        axis2: bool = false,
+        axis3: bool = false,
+
+        pub fn axis(self: @This(), a: u2) error{InvalidAxis}!bool {
+            return switch (a) {
+                0 => self.axis1,
+                1 => self.axis2,
+                2 => self.axis3,
+                _ => error.InvalidAxis,
+            };
+        }
+    } = .{},
+    transmission_stopped: packed struct(u2) { //X17,X18
+        from_prev: bool = false,
+        from_next: bool = false,
+
+        pub fn from(self: @This(), dir: Direction) bool {
+            return switch (dir) {
+                .backward => self.from_prev,
+                .forward => self.from_next,
+            };
+        }
+    } = .{},
+    errors_cleared: bool = false, //X19
+    communication_error: packed struct(u2) { //X1A,X1B
+        from_prev: bool = false,
+        from_next: bool = false,
+
+        pub fn from(self: @This(), dir: Direction) bool {
+            return switch (dir) {
+                .backward => self.from_prev,
+                .forward => self.from_next,
+            };
+        }
+    } = .{},
+    inverter_overheat_detected: bool = false, //X1C
+    overcurrent_detected: packed struct(u3) { //X1D,X1E,X1F
+        axis1: bool = false,
+        axis2: bool = false,
+        axis3: bool = false,
+
+        pub fn axis(self: @This(), a: u2) error{InvalidAxis}!bool {
+            return switch (a) {
+                0 => self.axis1,
+                1 => self.axis2,
+                2 => self.axis3,
+                _ => error.InvalidAxis,
+            };
+        }
+    } = .{},
+    control_failure: packed struct(u3) { //X20,X21,X22
+        axis1: bool = false,
+        axis2: bool = false,
+        axis3: bool = false,
+
+        pub fn axis(self: @This(), a: u2) error{InvalidAxis}!bool {
+            return switch (a) {
+                0 => self.axis1,
+                1 => self.axis2,
+                2 => self.axis3,
+                _ => error.InvalidAxis,
+            };
+        }
+    } = .{},
     hall_alarm: packed struct(u6) {
-        axis1: packed struct(u2) {
+        axis1: packed struct(u2) { //X23,X24
             back: bool = false,
             front: bool = false,
         } = .{},
-        axis2: packed struct(u2) {
+        axis2: packed struct(u2) { //X25,X26
             back: bool = false,
             front: bool = false,
         } = .{},
-        axis3: packed struct(u2) {
+        axis3: packed struct(u2) { //X27,X28
             back: bool = false,
             front: bool = false,
         } = .{},
 
-        pub fn axis(self: @This(), a: u2) packed struct(u2) {
+        pub fn axis(self: @This(), a: u2) error{InvalidAxis}!packed struct(u2) {
             back: bool,
             front: bool,
         } {
@@ -62,98 +167,89 @@ pub const X = packed struct(u64) {
                     .back = self.axis3.back,
                     .front = self.axis3.front,
                 },
-                3 => {
-                    std.log.err("Invalid axis index 3 for `hall_alarm`", .{});
-                    unreachable;
-                },
+                _ => error.InvalidAxis,
             };
         }
     } = .{},
-    _0xE: u2 = 0,
-    errors_cleared: bool = false,
-    vdc_undervoltage_detected: bool = false,
-    vdc_overvoltage_detected: bool = false,
-    communication_error: packed struct(u2) {
-        from_prev: bool = false,
-        from_next: bool = false,
-
-        pub fn to(self: @This(), dir: Direction) bool {
-            return switch (dir) {
-                .backward => self.to_prev,
-                .forward => self.to_next,
-            };
-        }
-    } = .{},
-    inverter_overheat_detected: bool = false,
-    overcurrent_detected: packed struct(u3) {
+    self_pause: packed struct(u3) { //X29,X2A,X2B
         axis1: bool = false,
         axis2: bool = false,
         axis3: bool = false,
 
-        pub fn axis(self: @This(), a: u2) bool {
+        pub fn axis(self: @This(), a: u2) error{InvalidAxis}!bool {
             return switch (a) {
                 0 => self.axis1,
                 1 => self.axis2,
                 2 => self.axis3,
-                3 => {
-                    std.log.err(
-                        "Invalid axis index 3 for `overcurrent_detected`",
-                        .{},
-                    );
-                    unreachable;
-                },
+                _ => error.InvalidAxis,
             };
         }
     } = .{},
-    control_loop_max_time_exceeded: bool = false,
-    _0x1A: u6 = 0,
-    wait_pull_carrier: packed struct(u3) {
+    pulling_slider: packed struct(u3) { //X2C,X2D,X2E
         axis1: bool = false,
         axis2: bool = false,
         axis3: bool = false,
 
-        pub fn axis(self: @This(), a: u2) bool {
+        pub fn axis(self: @This(), a: u2) error{InvalidAxis}!bool {
             return switch (a) {
                 0 => self.axis1,
                 1 => self.axis2,
                 2 => self.axis3,
-                3 => {
-                    std.log.err(
-                        "Invalid axis index 3 for `wait_pull_carrier`",
-                        .{},
-                    );
-                    unreachable;
-                },
+                _ => error.InvalidAxis,
             };
         }
     } = .{},
-    wait_push_carrier: packed struct(u3) {
+    _x2f: u1 = 0, //X2F
+    hall_alarm_abnormal: packed struct(u6) {
+        axis1: packed struct(u2) { //X30,X31
+            back: bool = false,
+            front: bool = false,
+        } = .{},
+        axis2: packed struct(u2) { //X32,X33
+            back: bool = false,
+            front: bool = false,
+        } = .{},
+        axis3: packed struct(u2) { //X34,X35
+            back: bool = false,
+            front: bool = false,
+        } = .{},
+
+        pub fn axis(
+            self: @This(),
+            a: u2,
+        ) error{InvalidAxis}!packed struct(u2) { back: bool, front: bool } {
+            return switch (a) {
+                0 => .{
+                    .back = self.axis1.back,
+                    .front = self.axis1.front,
+                },
+                1 => .{
+                    .back = self.axis2.back,
+                    .front = self.axis2.front,
+                },
+                2 => .{
+                    .back = self.axis3.back,
+                    .front = self.axis3.front,
+                },
+                _ => error.InvalidAxis,
+            };
+        }
+    } = .{},
+    lockup: packed struct(u3) { //X36,X37,X38
         axis1: bool = false,
         axis2: bool = false,
         axis3: bool = false,
 
-        pub fn axis(self: @This(), a: u2) bool {
+        pub fn axis(self: @This(), a: u2) error{InvalidAxis}!bool {
             return switch (a) {
                 0 => self.axis1,
                 1 => self.axis2,
                 2 => self.axis3,
-                3 => {
-                    std.log.err(
-                        "Invalid axis index 3 for `wait_push_carrier`",
-                        .{},
-                    );
-                    unreachable;
-                },
+                _ => error.InvalidAxis,
             };
         }
     } = .{},
-    _0x26: u10 = 0,
-    _0x30: u8 = 0,
-    initial_data_processing_request: bool = false,
-    initial_data_setting_complete: bool = false,
-    error_status: bool = false,
-    remote_ready: bool = false,
-    _60: u4 = 0,
+    _57: u7 = 0, //X39,X3A,X3B,X3C,X3D,X3E,X3F
 
     pub fn format(x: X, writer: anytype) !void {
         _ = try cclink.nestedWrite("X", x, 0, writer);

--- a/src/cclink/y.zig
+++ b/src/cclink/y.zig
@@ -52,7 +52,7 @@ pub const Y = packed struct(u64) {
                 0 => self.axis1,
                 1 => self.axis2,
                 2 => self.axis3,
-                _ => error.InvalidAxis,
+                else => unreachable,
             };
         }
 
@@ -65,7 +65,7 @@ pub const Y = packed struct(u64) {
                 0 => self.axis1 = true,
                 1 => self.axis2 = true,
                 2 => self.axis3 = true,
-                _ => return error.InvalidAxis,
+                else => unreachable,
             }
         }
 
@@ -78,7 +78,7 @@ pub const Y = packed struct(u64) {
                 0 => self.axis1 = false,
                 1 => self.axis2 = false,
                 2 => self.axis3 = false,
-                _ => return error.InvalidAxis,
+                else => unreachable,
             }
         }
     } = .{},
@@ -144,7 +144,7 @@ pub const Y = packed struct(u64) {
                     .backward = self.axis3.backward,
                     .forward = self.axis3.forward,
                 },
-                _ => error.InvalidAxis,
+                else => unreachable,
             };
         }
 
@@ -185,7 +185,7 @@ pub const Y = packed struct(u64) {
                         self.axis3.backward = true;
                     },
                 },
-                _ => return error.InvalidAxis,
+                else => unreachable,
             }
         }
 
@@ -220,7 +220,7 @@ pub const Y = packed struct(u64) {
                         self.axis3.backward = false;
                     },
                 },
-                _ => return error.InvalidAxis,
+                else => unreachable,
             }
         }
     } = .{},
@@ -259,7 +259,7 @@ pub const Y = packed struct(u64) {
                     .backward = self.axis3.backward,
                     .forward = self.axis3.forward,
                 },
-                _ => error.InvalidAxis,
+                else => unreachable,
             };
         }
 
@@ -300,7 +300,7 @@ pub const Y = packed struct(u64) {
                         self.axis3.backward = true;
                     },
                 },
-                _ => return error.InvalidAxis,
+                else => unreachable,
             }
         }
 
@@ -335,7 +335,7 @@ pub const Y = packed struct(u64) {
                         self.axis3.backward = false;
                     },
                 },
-                _ => return error.InvalidAxis,
+                else => unreachable,
             }
         }
     } = .{},
@@ -352,7 +352,7 @@ pub const Y = packed struct(u64) {
                 0 => self.axis1,
                 1 => self.axis2,
                 2 => self.axis3,
-                _ => error.InvalidAxis,
+                else => unreachable,
             };
         }
 
@@ -364,7 +364,7 @@ pub const Y = packed struct(u64) {
                 0 => self.axis1 = true,
                 1 => self.axis2 = true,
                 2 => self.axis3 = true,
-                _ => return error.InvalidAxis,
+                else => unreachable,
             }
         }
 
@@ -377,7 +377,7 @@ pub const Y = packed struct(u64) {
                 0 => self.axis1 = false,
                 1 => self.axis2 = false,
                 2 => self.axis3 = false,
-                _ => return error.InvalidAxis,
+                else => unreachable,
             }
         }
     } = .{},

--- a/src/cclink/y.zig
+++ b/src/cclink/y.zig
@@ -370,7 +370,7 @@ pub const Y = packed struct(u64) {
             }
         }
     } = .{},
-    _38: u25 = 0,
+    _38: u26 = 0,
 
     pub fn format(y: Y, writer: anytype) !void {
         _ = try cclink.nestedWrite("Y", y, 0, writer);

--- a/src/cclink/y.zig
+++ b/src/cclink/y.zig
@@ -6,168 +6,371 @@ const Direction = cclink.Direction;
 /// Registers written through CC-Link's "DevY" device. Used as a "write"
 /// register bank.
 pub const Y = packed struct(u64) {
-    cc_link_enable: bool = false,
-    emergency_stop: bool = false,
-    temporary_pause: bool = false,
-    release_motor: packed struct(u3) {
+    cc_link_enable: bool = false, //Y00
+    service_enable: bool = false, //Y01
+    start_command: bool = false, //Y02
+    reset_command_received: bool = false, //Y03
+    cancel_slider_commands: bool = false, //Y04, deprecated,
+    axis_servo_release: bool = false, //Y05,deprecated
+    release_control: bool = false, //Y06, Release all motor control
+    emergency_stop: bool = false, //Y07
+    temporary_pause: bool = false, //Y08
+    stop_driver_transmission: packed struct(u2) { //Y09,Y0A
+        from_prev: bool = false,
+        from_next: bool = false,
+
+        pub fn set(
+            self: *align(8:9:8) @This(),
+            dir: Direction,
+        ) void {
+            switch (dir) {
+                .backward => self.from_prev = true,
+                .forward => self.from_next = true,
+            }
+        }
+
+        pub fn reset(self: *align(8:9:8) @This(), dir: Direction) void {
+            switch (dir) {
+                .backward => self.from_prev = false,
+                .forward => self.from_next = false,
+            }
+        }
+    } = .{},
+    clear_errors: bool = false, //Y0B
+    clear_axis_slider_info: bool = false, //Y0C
+    prev_axis_isolate_link: bool = false, //Y0D
+    next_axis_isolate_link: bool = false, //Y0E
+    _15: u1 = 0, //Y0F
+    reset_pull_slider: packed struct(u3) { //Y10,Y11,Y12
         axis1: bool = false,
         axis2: bool = false,
         axis3: bool = false,
 
-        pub fn axis(self: @This(), local_axis: u2) bool {
-            return switch (local_axis) {
+        pub fn axis(self: @This(), a: u2) error{InvalidAxis}!bool {
+            return switch (a) {
                 0 => self.axis1,
                 1 => self.axis2,
                 2 => self.axis3,
-                3 => {
-                    std.log.err(
-                        "Invalid axis index 3 for `release_motor`",
-                        .{},
-                    );
-                    unreachable;
-                },
+                _ => error.InvalidAxis,
             };
         }
 
         pub fn setAxis(
-            self: *align(8:3:8) @This(),
+            self: *align(8:16:8) @This(),
             local_axis: u2,
-            val: bool,
-        ) void {
+        ) error{InvalidAxis}!void {
             switch (local_axis) {
-                0 => self.axis1 = val,
-                1 => self.axis2 = val,
-                2 => self.axis3 = val,
-                3 => {
-                    std.log.err(
-                        "Invalid axis index 3 for `release_motor`",
-                        .{},
-                    );
-                    unreachable;
-                },
+                0 => self.axis1 = true,
+                1 => self.axis2 = true,
+                2 => self.axis3 = true,
+                _ => return error.InvalidAxis,
+            }
+        }
+
+        pub fn resetAxis(
+            self: *align(8:16:8) @This(),
+            local_axis: u2,
+        ) error{InvalidAxis}!void {
+            switch (local_axis) {
+                0 => self.axis1 = false,
+                1 => self.axis2 = false,
+                2 => self.axis3 = false,
+                _ => return error.InvalidAxis,
             }
         }
     } = .{},
-    deinitialize_carrier: packed struct(u3) {
+    recovery_use_hall_sensor: packed struct(u2) { //Y13,Y14
+        back: bool = false,
+        front: bool = false,
+
+        pub fn side(self: @This(), dir: Direction) bool {
+            return switch (dir) {
+                .backward => self.back,
+                .forward => self.front,
+            };
+        }
+
+        pub fn setSide(
+            self: *align(8:19:8) @This(),
+            dir: Direction,
+        ) void {
+            switch (dir) {
+                .backward => self.back = true,
+                .forward => self.front = true,
+            }
+        }
+        pub fn resetSide(
+            self: *align(8:19:8) @This(),
+            dir: Direction,
+        ) void {
+            switch (dir) {
+                .backward => self.back = false,
+                .forward => self.front = false,
+            }
+        }
+    } = .{},
+    link_chain: packed struct(u6) { //Y15,Y16,Y17,Y18,Y19,Y1A
+        axis1: packed struct(u2) {
+            backward: bool = false,
+            forward: bool = false,
+        } = .{},
+        axis2: packed struct(u2) {
+            backward: bool = false,
+            forward: bool = false,
+        } = .{},
+        axis3: packed struct(u2) {
+            backward: bool = false,
+            forward: bool = false,
+        } = .{},
+
+        pub fn axis(self: @This(), a: u2) error{InvalidAxis}!packed struct(u2) {
+            backward: bool,
+            forward: bool,
+        } {
+            return switch (a) {
+                0 => .{
+                    .backward = self.axis1.backward,
+                    .forward = self.axis1.forward,
+                },
+                1 => .{
+                    .backward = self.axis2.backward,
+                    .forward = self.axis2.forward,
+                },
+                2 => .{
+                    .backward = self.axis3.backward,
+                    .forward = self.axis3.forward,
+                },
+                _ => error.InvalidAxis,
+            };
+        }
+
+        const ChainSide = enum {
+            Forward,
+            Backward,
+            BothSide,
+        };
+
+        pub fn setAxis(
+            self: *align(8:21:8) @This(),
+            a: u2,
+            side: ChainSide,
+        ) error{InvalidAxis}!void {
+            switch (a) {
+                0 => switch (side) {
+                    .Forward => self.axis1.forward = true,
+                    .Backward => self.axis1.backward = true,
+                    .BothSide => {
+                        self.axis1.forward = true;
+                        self.axis1.backward = true;
+                    },
+                },
+                1 => switch (side) {
+                    .Forward => self.axis2.forward = true,
+                    .Backward => self.axis2.backward = true,
+                    .BothSide => {
+                        self.axis2.forward = true;
+                        self.axis2.backward = true;
+                    },
+                },
+                2 => switch (side) {
+                    .Forward => self.axis3.forward = true,
+                    .Backward => self.axis3.backward = true,
+                    .BothSide => {
+                        self.axis3.forward = true;
+                        self.axis3.backward = true;
+                    },
+                },
+                _ => return error.InvalidAxis,
+            }
+        }
+
+        pub fn resetAxis(
+            self: *align(8:21:8) @This(),
+            a: u2,
+            side: ChainSide,
+        ) error{InvalidAxis}!void {
+            switch (a) {
+                0 => switch (side) {
+                    .Forward => self.axis1.forward = false,
+                    .Backward => self.axis1.backward = false,
+                    .BothSide => {
+                        self.axis1.forward = false;
+                        self.axis1.backward = false;
+                    },
+                },
+                1 => switch (side) {
+                    .Forward => self.axis2.forward = false,
+                    .Backward => self.axis2.backward = false,
+                    .BothSide => {
+                        self.axis2.forward = false;
+                        self.axis2.backward = false;
+                    },
+                },
+                2 => switch (side) {
+                    .Forward => self.axis3.forward = false,
+                    .Backward => self.axis3.backward = false,
+                    .BothSide => {
+                        self.axis3.forward = false;
+                        self.axis3.backward = false;
+                    },
+                },
+                _ => return error.InvalidAxis,
+            }
+        }
+    } = .{},
+    unlink_chain: packed struct(u6) { //Y1B,Y1C,Y1D,Y1E,Y1F,Y20
+        axis1: packed struct(u2) {
+            backward: bool = false,
+            forward: bool = false,
+        } = .{},
+        axis2: packed struct(u2) {
+            backward: bool = false,
+            forward: bool = false,
+        } = .{},
+        axis3: packed struct(u2) {
+            backward: bool = false,
+            forward: bool = false,
+        } = .{},
+
+        pub fn axis(
+            self: @This(),
+            a: u2,
+        ) error{InvalidAxis}!packed struct(u2) {
+            backward: bool,
+            forward: bool,
+        } {
+            return switch (a) {
+                0 => .{
+                    .backward = self.axis1.backward,
+                    .forward = self.axis1.forward,
+                },
+                1 => .{
+                    .backward = self.axis2.backward,
+                    .forward = self.axis2.forward,
+                },
+                2 => .{
+                    .backward = self.axis3.backward,
+                    .forward = self.axis3.forward,
+                },
+                _ => error.InvalidAxis,
+            };
+        }
+
+        const ChainSide = enum {
+            Forward,
+            Backward,
+            BothSide,
+        };
+
+        pub fn setAxis(
+            self: *align(8:27:8) @This(),
+            a: u2,
+            side: ChainSide,
+        ) error{InvalidAxis}!void {
+            switch (a) {
+                0 => switch (side) {
+                    .Forward => self.axis1.forward = true,
+                    .Backward => self.axis1.backward = true,
+                    .BothSide => {
+                        self.axis1.forward = true;
+                        self.axis1.backward = true;
+                    },
+                },
+                1 => switch (side) {
+                    .Forward => self.axis2.forward = true,
+                    .Backward => self.axis2.backward = true,
+                    .BothSide => {
+                        self.axis2.forward = true;
+                        self.axis2.backward = true;
+                    },
+                },
+                2 => switch (side) {
+                    .Forward => self.axis3.forward = true,
+                    .Backward => self.axis3.backward = true,
+                    .BothSide => {
+                        self.axis3.forward = true;
+                        self.axis3.backward = true;
+                    },
+                },
+                _ => return error.InvalidAxis,
+            }
+        }
+
+        pub fn resetAxis(
+            self: *align(8:27:8) @This(),
+            a: u2,
+            side: ChainSide,
+        ) error{InvalidAxis}!void {
+            switch (a) {
+                0 => switch (side) {
+                    .Forward => self.axis1.forward = false,
+                    .Backward => self.axis1.backward = false,
+                    .BothSide => {
+                        self.axis1.forward = false;
+                        self.axis1.backward = false;
+                    },
+                },
+                1 => switch (side) {
+                    .Forward => self.axis2.forward = false,
+                    .Backward => self.axis2.backward = false,
+                    .BothSide => {
+                        self.axis2.forward = false;
+                        self.axis2.backward = false;
+                    },
+                },
+                2 => switch (side) {
+                    .Forward => self.axis3.forward = false,
+                    .Backward => self.axis3.backward = false,
+                    .BothSide => {
+                        self.axis3.forward = false;
+                        self.axis3.backward = false;
+                    },
+                },
+                _ => return error.InvalidAxis,
+            }
+        }
+    } = .{},
+    get_speed_info: bool, //Y21,
+    get_current_info: bool, //Y22
+    lockup: packed struct(u3) { //Y23,Y24,Y25
         axis1: bool = false,
         axis2: bool = false,
         axis3: bool = false,
 
-        pub fn axis(self: @This(), local_axis: u2) bool {
-            return switch (local_axis) {
+        pub fn axis(self: @This(), a: u2) error{InvalidAxis}!bool {
+            return switch (a) {
                 0 => self.axis1,
                 1 => self.axis2,
                 2 => self.axis3,
-                3 => {
-                    std.log.err(
-                        "Invalid axis index 3 for `deinitialize_carrier`",
-                        .{},
-                    );
-                    unreachable;
-                },
+                _ => error.InvalidAxis,
             };
         }
 
         pub fn setAxis(
-            self: *align(8:6:8) @This(),
+            self: *align(8:35:8) @This(),
             local_axis: u2,
-            val: bool,
-        ) void {
+        ) error{InvalidAxis}!void {
             switch (local_axis) {
-                0 => self.axis1 = val,
-                1 => self.axis2 = val,
-                2 => self.axis3 = val,
-                3 => {
-                    std.log.err(
-                        "Invalid axis index 3 for `deinitialize_carrier`",
-                        .{},
-                    );
-                    unreachable;
-                },
+                0 => self.axis1 = true,
+                1 => self.axis2 = true,
+                2 => self.axis3 = true,
+                _ => return error.InvalidAxis,
+            }
+        }
+
+        pub fn resetAxis(
+            self: *align(8:35:8) @This(),
+            local_axis: u2,
+        ) error{InvalidAxis}!void {
+            switch (local_axis) {
+                0 => self.axis1 = false,
+                1 => self.axis2 = false,
+                2 => self.axis3 = false,
+                _ => return error.InvalidAxis,
             }
         }
     } = .{},
-    calibrate: bool = false,
-    clear_errors: bool = false,
-    stop_pull_carrier: packed struct(u3) {
-        axis1: bool = false,
-        axis2: bool = false,
-        axis3: bool = false,
-
-        pub fn axis(self: @This(), local_axis: u2) bool {
-            return switch (local_axis) {
-                0 => self.axis1,
-                1 => self.axis2,
-                2 => self.axis3,
-                3 => {
-                    std.log.err(
-                        "Invalid axis index 3 for `stop_pull_carrier`",
-                        .{},
-                    );
-                    unreachable;
-                },
-            };
-        }
-
-        pub fn setAxis(
-            self: *align(8:11:8) @This(),
-            local_axis: u2,
-            val: bool,
-        ) void {
-            switch (local_axis) {
-                0 => self.axis1 = val,
-                1 => self.axis2 = val,
-                2 => self.axis3 = val,
-                3 => {
-                    std.log.err(
-                        "Invalid axis index 3 for `stop_pull_carrier`",
-                        .{},
-                    );
-                    unreachable;
-                },
-            }
-        }
-    } = .{},
-    stop_push_carrier: packed struct(u3) {
-        axis1: bool = false,
-        axis2: bool = false,
-        axis3: bool = false,
-
-        pub fn axis(self: @This(), local_axis: u2) bool {
-            return switch (local_axis) {
-                0 => self.axis1,
-                1 => self.axis2,
-                2 => self.axis3,
-                3 => {
-                    std.log.err(
-                        "Invalid axis index 3 for `stop_push_carrier`",
-                        .{},
-                    );
-                    unreachable;
-                },
-            };
-        }
-
-        pub fn setAxis(
-            self: *align(8:14:8) @This(),
-            local_axis: u2,
-            val: bool,
-        ) void {
-            switch (local_axis) {
-                0 => self.axis1 = val,
-                1 => self.axis2 = val,
-                2 => self.axis3 = val,
-                3 => {
-                    std.log.err(
-                        "Invalid axis index 3 for `stop_push_carrier`",
-                        .{},
-                    );
-                    unreachable;
-                },
-            }
-        }
-    } = .{},
-    _22: u47 = 0,
+    _38: u25 = 0,
 
     pub fn format(y: Y, writer: anytype) !void {
         _ = try cclink.nestedWrite("Y", y, 0, writer);

--- a/src/cclink/y.zig
+++ b/src/cclink/y.zig
@@ -46,8 +46,9 @@ pub const Y = packed struct(u64) {
         axis2: bool = false,
         axis3: bool = false,
 
-        pub fn axis(self: @This(), a: u2) error{InvalidAxis}!bool {
-            return switch (a) {
+        pub fn axis(self: @This(), local_axis: u2) bool {
+            std.debug.assert(local_axis <= 2);
+            return switch (local_axis) {
                 0 => self.axis1,
                 1 => self.axis2,
                 2 => self.axis3,
@@ -58,7 +59,8 @@ pub const Y = packed struct(u64) {
         pub fn setAxis(
             self: *align(8:16:8) @This(),
             local_axis: u2,
-        ) error{InvalidAxis}!void {
+        ) void {
+            std.debug.assert(local_axis <= 2);
             switch (local_axis) {
                 0 => self.axis1 = true,
                 1 => self.axis2 = true,
@@ -70,7 +72,8 @@ pub const Y = packed struct(u64) {
         pub fn resetAxis(
             self: *align(8:16:8) @This(),
             local_axis: u2,
-        ) error{InvalidAxis}!void {
+        ) void {
+            std.debug.assert(local_axis <= 2);
             switch (local_axis) {
                 0 => self.axis1 = false,
                 1 => self.axis2 = false,
@@ -123,11 +126,12 @@ pub const Y = packed struct(u64) {
             forward: bool = false,
         } = .{},
 
-        pub fn axis(self: @This(), a: u2) error{InvalidAxis}!packed struct(u2) {
+        pub fn axis(self: @This(), local_axis: u2) packed struct(u2) {
             backward: bool,
             forward: bool,
         } {
-            return switch (a) {
+            std.debug.assert(local_axis <= 2);
+            return switch (local_axis) {
                 0 => .{
                     .backward = self.axis1.backward,
                     .forward = self.axis1.forward,
@@ -152,10 +156,11 @@ pub const Y = packed struct(u64) {
 
         pub fn setAxis(
             self: *align(8:21:8) @This(),
-            a: u2,
+            local_axis: u2,
             side: ChainSide,
-        ) error{InvalidAxis}!void {
-            switch (a) {
+        ) void {
+            std.debug.assert(local_axis <= 2);
+            switch (local_axis) {
                 0 => switch (side) {
                     .Forward => self.axis1.forward = true,
                     .Backward => self.axis1.backward = true,
@@ -186,10 +191,11 @@ pub const Y = packed struct(u64) {
 
         pub fn resetAxis(
             self: *align(8:21:8) @This(),
-            a: u2,
+            local_axis: u2,
             side: ChainSide,
-        ) error{InvalidAxis}!void {
-            switch (a) {
+        ) void {
+            std.debug.assert(local_axis <= 2);
+            switch (local_axis) {
                 0 => switch (side) {
                     .Forward => self.axis1.forward = false,
                     .Backward => self.axis1.backward = false,
@@ -234,12 +240,13 @@ pub const Y = packed struct(u64) {
 
         pub fn axis(
             self: @This(),
-            a: u2,
-        ) error{InvalidAxis}!packed struct(u2) {
+            local_axis: u2,
+        ) packed struct(u2) {
             backward: bool,
             forward: bool,
         } {
-            return switch (a) {
+            std.debug.assert(local_axis <= 2);
+            return switch (local_axis) {
                 0 => .{
                     .backward = self.axis1.backward,
                     .forward = self.axis1.forward,
@@ -264,10 +271,11 @@ pub const Y = packed struct(u64) {
 
         pub fn setAxis(
             self: *align(8:27:8) @This(),
-            a: u2,
+            local_axis: u2,
             side: ChainSide,
-        ) error{InvalidAxis}!void {
-            switch (a) {
+        ) void {
+            std.debug.assert(local_axis <= 2);
+            switch (local_axis) {
                 0 => switch (side) {
                     .Forward => self.axis1.forward = true,
                     .Backward => self.axis1.backward = true,
@@ -298,10 +306,11 @@ pub const Y = packed struct(u64) {
 
         pub fn resetAxis(
             self: *align(8:27:8) @This(),
-            a: u2,
+            local_axis: u2,
             side: ChainSide,
-        ) error{InvalidAxis}!void {
-            switch (a) {
+        ) void {
+            std.debug.assert(local_axis <= 2);
+            switch (local_axis) {
                 0 => switch (side) {
                     .Forward => self.axis1.forward = false,
                     .Backward => self.axis1.backward = false,
@@ -337,8 +346,9 @@ pub const Y = packed struct(u64) {
         axis2: bool = false,
         axis3: bool = false,
 
-        pub fn axis(self: @This(), a: u2) error{InvalidAxis}!bool {
-            return switch (a) {
+        pub fn axis(self: @This(), local_axis: u2) bool {
+            std.debug.assert(local_axis <= 2);
+            return switch (local_axis) {
                 0 => self.axis1,
                 1 => self.axis2,
                 2 => self.axis3,
@@ -349,7 +359,7 @@ pub const Y = packed struct(u64) {
         pub fn setAxis(
             self: *align(8:35:8) @This(),
             local_axis: u2,
-        ) error{InvalidAxis}!void {
+        ) void {
             switch (local_axis) {
                 0 => self.axis1 = true,
                 1 => self.axis2 = true,
@@ -361,7 +371,8 @@ pub const Y = packed struct(u64) {
         pub fn resetAxis(
             self: *align(8:35:8) @This(),
             local_axis: u2,
-        ) error{InvalidAxis}!void {
+        ) void {
+            std.debug.assert(local_axis <= 2);
             switch (local_axis) {
                 0 => self.axis1 = false,
                 1 => self.axis2 = false,


### PR DESCRIPTION
Migrate cclink registers to the one used in CTO's firmware. Deprecated every bits use previously from John's firmware.